### PR TITLE
Fix the composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,9 @@
     ],
 
     "require": {
-        "php":                            ">=5.3.9"
-    },
-    "require-dev": {
-        "symfony/security":       "~2.6"
+        "php":                            ">=5.3.9",
+        "symfony/security-core":       "~2.6",
+        "symfony/security-http":       "~2.6"
     },
 
     "autoload": {


### PR DESCRIPTION
Most classes in this library are either extending a symfony class or implementing a symfony interface, so this is not only a dev requirement but an actual requirement.

I also changed the constraints to avoid the installation of the ACL component thanks to the more specific security packages
