### PR TITLE
Improve the travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,16 @@ matrix:
     - php: 5.5
       env: SYMFONY_VERSION=2.6.*
     - php: 5.5
-      env: SYMFONY_VERSION=2.6.*
-    - php: 5.5
       env: SYMFONY_VERSION='2.7.*@dev'
+      
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 script: phpunit
 
 before_script:
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
-  - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
-  - if [ "$deps" != "low" ]; then composer update --prefer-source; fi
+  - if [ "$deps" = "low" ]; then export COMPOSER_FLAGS='--prefer-lowest'; fi
+  - composer update $COMPOSER_FLAGS


### PR DESCRIPTION
- persist the composer cache between builds
- let composer use dist archives to benefit from their caching
- remove duplicate job definition from the matrix
